### PR TITLE
Feat : 유저 정보 수정 API

### DIFF
--- a/api_gate_way/src/domain/user/user.controller.ts
+++ b/api_gate_way/src/domain/user/user.controller.ts
@@ -1,18 +1,24 @@
 import { Controller, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { TypedBody, TypedParam, TypedRoute } from '@nestia/core';
-import { CreateUserDto } from 'src/dtos/user/create-user.dto';
+import {
+  CreateUserDto,
+  CreateUserOutboundPortOutputDto,
+} from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
 import { JwtLocalGuard } from 'src/auth/guards/jwt-local.guard';
 import { User } from 'src/middlewares/decorators/user.decorator';
 import { LocalToken } from 'src/dtos/auth/local-token.dto';
+import { UpdateUserEtcInfoInboundPortInputDto } from 'src/dtos/user/update-user.dto';
 
 @Controller('/api/v1/user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @TypedRoute.Post('sign-up')
-  async register(@TypedBody() userInfo: CreateUserDto): Promise<CreateUserDto> {
+  async register(
+    @TypedBody() userInfo: CreateUserDto,
+  ): Promise<CreateUserOutboundPortOutputDto> {
     const user = await this.userService.register(userInfo);
 
     return user;
@@ -26,6 +32,17 @@ export class UserController {
     const userId = user.id;
 
     const userInfo = await this.userService.getUserInfo(userId);
+
+    return userInfo;
+  }
+
+  @UseGuards(JwtLocalGuard)
+  @TypedRoute.Put('info')
+  async modifyUserEtcInfo(
+    @User() user: LocalToken,
+    @TypedBody() body: UpdateUserEtcInfoInboundPortInputDto,
+  ): Promise<FindUserInfoOutboundPortOutputDto> {
+    const userInfo = await this.userService.modifyUserEtcInfo(user.id, body);
 
     return userInfo;
   }

--- a/api_gate_way/src/domain/user/user.service.ts
+++ b/api_gate_way/src/domain/user/user.service.ts
@@ -1,6 +1,10 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
-import { CreateUserDto } from 'src/dtos/user/create-user.dto';
+import {
+  CreateUserDto,
+  CreateUserOutboundPortOutputDto,
+} from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
+import { UpdateUserEtcInfoInboundPortInputDto } from 'src/dtos/user/update-user.dto';
 import {
   USER_REPOSITORY_OUTBOUND_PORT,
   UserRepositoryOutboundPort,
@@ -13,7 +17,9 @@ export class UserService {
     private readonly userRepository: UserRepositoryOutboundPort,
   ) {}
 
-  async register(userInfo: CreateUserDto): Promise<CreateUserDto> {
+  async register(
+    userInfo: CreateUserDto,
+  ): Promise<CreateUserOutboundPortOutputDto> {
     const oldUser = await this.userRepository.findUserForSignUp(userInfo.email);
 
     if (oldUser !== null) {
@@ -34,6 +40,15 @@ export class UserService {
     if (!user) {
       throw new BadRequestException('잘못된 요청입니다.');
     }
+
+    return user;
+  }
+
+  async modifyUserEtcInfo(
+    userId: number,
+    data: UpdateUserEtcInfoInboundPortInputDto,
+  ): Promise<FindUserInfoOutboundPortOutputDto> {
+    const user = await this.userRepository.updateUserInfo(userId, data);
 
     return user;
   }

--- a/api_gate_way/src/dtos/user/create-user.dto.ts
+++ b/api_gate_way/src/dtos/user/create-user.dto.ts
@@ -6,6 +6,11 @@ export type CreateUserDto = OmitProperties<
   'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
 >;
 
-export type CreateUserDtoForSelect = {
-  [P in keyof CreateUserDto as `${P}`]: CreateUserDto[P];
+export type CreateUserOutboundPortOutputDto = OmitProperties<
+  UserEntity,
+  'updatedAt' | 'deletedAt'
+>;
+
+export type CreateUserOutboundPortOutputDtoForSelect = {
+  [P in keyof CreateUserOutboundPortOutputDto as `${P}`]: CreateUserOutboundPortOutputDto[P];
 };

--- a/api_gate_way/src/dtos/user/find-user-info.dto.ts
+++ b/api_gate_way/src/dtos/user/find-user-info.dto.ts
@@ -3,7 +3,7 @@ import { OmitProperties } from 'src/utils/types/omit.type';
 
 export type FindUserInfoOutboundPortOutputDto = OmitProperties<
   UserEntity,
-  'id' | 'updatedAt' | 'deletedAt' | 'password'
+  'updatedAt' | 'deletedAt' | 'password'
 >;
 
 export type FindUserInfoOutboundPortOutputDtoForSelect = {

--- a/api_gate_way/src/dtos/user/update-user.dto.ts
+++ b/api_gate_way/src/dtos/user/update-user.dto.ts
@@ -1,0 +1,6 @@
+import { UserEntity } from 'src/config/database/models/user.entity';
+import { OmitProperties } from 'src/utils/types/omit.type';
+
+export type UpdateUserDto = Partial<
+  OmitProperties<UserEntity, 'createdAt' | 'updatedAt' | 'deletedAt' | 'id'>
+>;

--- a/api_gate_way/src/dtos/user/update-user.dto.ts
+++ b/api_gate_way/src/dtos/user/update-user.dto.ts
@@ -4,3 +4,16 @@ import { OmitProperties } from 'src/utils/types/omit.type';
 export type UpdateUserDto = Partial<
   OmitProperties<UserEntity, 'createdAt' | 'updatedAt' | 'deletedAt' | 'id'>
 >;
+
+export type UpdateUserEtcInfoInboundPortInputDto = OmitProperties<
+  UserEntity,
+  | 'createdAt'
+  | 'updatedAt'
+  | 'deletedAt'
+  | 'id'
+  | 'email'
+  | 'password'
+  | 'phoneNumber'
+  | 'profilePhotoUrl'
+  | 'nickname'
+>;

--- a/api_gate_way/src/ports-adapters/user/user.repository.outbound-port.ts
+++ b/api_gate_way/src/ports-adapters/user/user.repository.outbound-port.ts
@@ -1,5 +1,8 @@
 import { UserEntity } from 'src/config/database/models/user.entity';
-import { CreateUserDto } from 'src/dtos/user/create-user.dto';
+import {
+  CreateUserDto,
+  CreateUserOutboundPortOutputDto,
+} from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
 import { UpdateUserDto } from 'src/dtos/user/update-user.dto';
 
@@ -7,7 +10,7 @@ export const USER_REPOSITORY_OUTBOUND_PORT =
   'USER_REPOSITORY_OUTBOUND_PORT' as const;
 
 export interface UserRepositoryOutboundPort {
-  insertUser(userInfo: CreateUserDto): Promise<CreateUserDto>;
+  insertUser(userInfo: CreateUserDto): Promise<CreateUserOutboundPortOutputDto>;
   findUserForSignUp(email: string): Promise<UserEntity | null>;
   findUserInfo(
     userId: number,

--- a/api_gate_way/src/ports-adapters/user/user.repository.outbound-port.ts
+++ b/api_gate_way/src/ports-adapters/user/user.repository.outbound-port.ts
@@ -1,6 +1,7 @@
 import { UserEntity } from 'src/config/database/models/user.entity';
 import { CreateUserDto } from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
+import { UpdateUserDto } from 'src/dtos/user/update-user.dto';
 
 export const USER_REPOSITORY_OUTBOUND_PORT =
   'USER_REPOSITORY_OUTBOUND_PORT' as const;
@@ -11,4 +12,8 @@ export interface UserRepositoryOutboundPort {
   findUserInfo(
     userId: number,
   ): Promise<FindUserInfoOutboundPortOutputDto | null>;
+  updateUserInfo(
+    userId: number,
+    data: UpdateUserDto,
+  ): Promise<FindUserInfoOutboundPortOutputDto>;
 }

--- a/api_gate_way/src/ports-adapters/user/user.repository.ts
+++ b/api_gate_way/src/ports-adapters/user/user.repository.ts
@@ -3,7 +3,8 @@ import { PrismaService } from 'src/config/database/prisma/prisma.service';
 import { UserRepositoryOutboundPort } from './user.repository.outbound-port';
 import {
   CreateUserDto,
-  CreateUserDtoForSelect,
+  CreateUserOutboundPortOutputDto,
+  CreateUserOutboundPortOutputDtoForSelect,
 } from 'src/dtos/user/create-user.dto';
 import typia from 'typia';
 import { TypeToSelect } from 'src/utils/types/type-to-select.type';
@@ -14,19 +15,21 @@ import {
   FindUserInfoOutboundPortOutputDto,
   FindUserInfoOutboundPortOutputDtoForSelect,
 } from 'src/dtos/user/find-user-info.dto';
-import { OmitProperties } from 'src/utils/types/omit.type';
 import { UpdateUserDto } from 'src/dtos/user/update-user.dto';
 
 @Injectable()
 export class UserRepository implements UserRepositoryOutboundPort {
   constructor(private readonly prisma: PrismaService) {}
 
-  async insertUser(userInfo: CreateUserDto): Promise<CreateUserDto> {
+  async insertUser(
+    userInfo: CreateUserDto,
+  ): Promise<CreateUserOutboundPortOutputDto> {
     const { password, ...data } = userInfo;
     const hashedPassword = await bcrypt.hash(password, 10);
 
     const user = await this.prisma.user.create({
-      select: typia.random<TypeToSelect<CreateUserDtoForSelect>>(),
+      select:
+        typia.random<TypeToSelect<CreateUserOutboundPortOutputDtoForSelect>>(),
       data: { ...data, password: hashedPassword },
     });
 

--- a/api_gate_way/src/ports-adapters/user/user.repository.ts
+++ b/api_gate_way/src/ports-adapters/user/user.repository.ts
@@ -14,6 +14,8 @@ import {
   FindUserInfoOutboundPortOutputDto,
   FindUserInfoOutboundPortOutputDtoForSelect,
 } from 'src/dtos/user/find-user-info.dto';
+import { OmitProperties } from 'src/utils/types/omit.type';
+import { UpdateUserDto } from 'src/dtos/user/update-user.dto';
 
 @Injectable()
 export class UserRepository implements UserRepositoryOutboundPort {
@@ -61,6 +63,24 @@ export class UserRepository implements UserRepositoryOutboundPort {
     if (!user) {
       return null;
     }
+
+    return dateToString(user);
+  }
+
+  async updateUserInfo(
+    userId: number,
+    data: UpdateUserDto,
+  ): Promise<FindUserInfoOutboundPortOutputDto> {
+    const user = await this.prisma.user.update({
+      select:
+        typia.random<
+          TypeToSelect<FindUserInfoOutboundPortOutputDtoForSelect>
+        >(),
+      data: { ...data },
+      where: {
+        id: userId,
+      },
+    });
 
     return dateToString(user);
   }

--- a/api_gate_way/src/test/unit/mock/user.repository.mock.ts
+++ b/api_gate_way/src/test/unit/mock/user.repository.mock.ts
@@ -4,8 +4,10 @@ import {
   CreateUserOutboundPortOutputDto,
 } from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
+import { UpdateUserEtcInfoInboundPortInputDto } from 'src/dtos/user/update-user.dto';
 import { UserRepositoryOutboundPort } from 'src/ports-adapters/user/user.repository.outbound-port';
 import { MockParamTypeForTest } from 'src/utils/types/mock-param-type-for-test.type';
+import { OmitProperties } from 'src/utils/types/omit.type';
 
 type MockUserRepositoryParamType = MockParamTypeForTest<MockUserRepository>;
 
@@ -38,6 +40,17 @@ export class MockUserRepository implements UserRepositoryOutboundPort {
     userId: number,
   ): Promise<FindUserInfoOutboundPortOutputDto | null> {
     const res = this.result.findUserInfo?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+    return res;
+  }
+
+  async updateUserInfo(
+    userId: number,
+    data: UpdateUserEtcInfoInboundPortInputDto,
+  ): Promise<FindUserInfoOutboundPortOutputDto> {
+    const res = this.result.updateUserInfo?.pop();
     if (res === undefined) {
       throw new Error('undefined');
     }

--- a/api_gate_way/src/test/unit/mock/user.repository.mock.ts
+++ b/api_gate_way/src/test/unit/mock/user.repository.mock.ts
@@ -1,9 +1,11 @@
 import { UserEntity } from 'src/config/database/models/user.entity';
-import { CreateUserDto } from 'src/dtos/user/create-user.dto';
+import {
+  CreateUserDto,
+  CreateUserOutboundPortOutputDto,
+} from 'src/dtos/user/create-user.dto';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
 import { UserRepositoryOutboundPort } from 'src/ports-adapters/user/user.repository.outbound-port';
 import { MockParamTypeForTest } from 'src/utils/types/mock-param-type-for-test.type';
-import { OmitProperties } from 'src/utils/types/omit.type';
 
 type MockUserRepositoryParamType = MockParamTypeForTest<MockUserRepository>;
 
@@ -14,7 +16,9 @@ export class MockUserRepository implements UserRepositoryOutboundPort {
     this.result = result;
   }
 
-  async insertUser(userInfo: CreateUserDto): Promise<CreateUserDto> {
+  async insertUser(
+    userInfo: CreateUserDto,
+  ): Promise<CreateUserOutboundPortOutputDto> {
     const res = this.result.insertUser?.pop();
     if (res === undefined) {
       throw new Error('undefined');

--- a/api_gate_way/src/test/unit/user.spec.ts
+++ b/api_gate_way/src/test/unit/user.spec.ts
@@ -2,18 +2,22 @@ import { UserService } from 'src/domain/user/user.service';
 import { MockUserRepository } from './mock/user.repository.mock';
 import { UserController } from 'src/domain/user/user.controller';
 import typia from 'typia';
-import { CreateUserDto } from 'src/dtos/user/create-user.dto';
+import {
+  CreateUserDto,
+  CreateUserOutboundPortOutputDto,
+} from 'src/dtos/user/create-user.dto';
 import { UserEntity } from 'src/config/database/models/user.entity';
 import { AuthService } from 'src/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
 import { AuthController } from 'src/auth/auth.controller';
 import { FindUserInfoOutboundPortOutputDto } from 'src/dtos/user/find-user-info.dto';
 import { LocalToken } from 'src/dtos/auth/local-token.dto';
+import { UpdateUserEtcInfoInboundPortInputDto } from 'src/dtos/user/update-user.dto';
 
 describe('User Spec', () => {
   describe('1. Register User', () => {
     it('1-1. Sign up', async () => {
-      const userInfo = typia.random<CreateUserDto>();
+      const userInfo = typia.random<CreateUserOutboundPortOutputDto>();
 
       const userService = new UserService(
         new MockUserRepository({
@@ -75,6 +79,24 @@ describe('User Spec', () => {
       const userController = new UserController(userService);
 
       const res = await userController.getOwnUserInfo(user);
+
+      expect(res).toStrictEqual(userInfo);
+    });
+
+    it('3-2. Update User Etc Info', async () => {
+      const user = typia.random<LocalToken>();
+      const userInfo = typia.random<FindUserInfoOutboundPortOutputDto>();
+      const data = typia.random<UpdateUserEtcInfoInboundPortInputDto>();
+
+      const userService = new UserService(
+        new MockUserRepository({
+          updateUserInfo: [userInfo],
+        }),
+      );
+
+      const userController = new UserController(userService);
+
+      const res = await userController.modifyUserEtcInfo(user, data);
 
       expect(res).toStrictEqual(userInfo);
     });


### PR DESCRIPTION
## 개요

- 사용자 본인이 이메일, 비밀번호, 프로필사진, 핸드폰번호, 닉네임을 제외한 유저 정보를 수정할 수 있다.

## ✅ 작업 내용

- findUserInfo in UserRepository
- modifyUserEtcInfo in UserService
- modifyUserEtcInfo in UserController
- Update User Etc Info Test

## 🔨 변경 로직

- CreateUserDto

## 🧨 관련 이슈

- close #14 
