### PR TITLE
Fix : 유저 비밀번호 변경 시, 현재 비밀번호가 필요하도록 수정

### DIFF
--- a/api_gate_way/src/domain/user/user.controller.ts
+++ b/api_gate_way/src/domain/user/user.controller.ts
@@ -104,8 +104,7 @@ export class UserController {
     @Body() body: UpdateUserPasswordInboundPortInputDto,
   ): Promise<UpdateUserPasswordOutboundPortOutputDto> {
     const userInfo = await this.userService.modifyPassword(user.id, {
-      password: body.password,
-      passwordConfirm: body.passwordConfirm,
+      ...body,
     });
 
     return userInfo;

--- a/api_gate_way/src/dtos/user/update-user.dto.ts
+++ b/api_gate_way/src/dtos/user/update-user.dto.ts
@@ -47,8 +47,9 @@ export type UpdateUserEmailInboundPortInputDto = Pick<UserEntity, 'email'>;
 export type UpdateUserEmailOutboundPortOutputDto = Pick<UserEntity, 'email'>;
 
 // update password
-export interface UpdateUserPasswordInboundPortInputDto
-  extends Pick<UserEntity, 'password'> {
+export interface UpdateUserPasswordInboundPortInputDto {
+  currentPassword: string;
+  modifiedPassword: string;
   passwordConfirm: string;
 }
 


### PR DESCRIPTION
## 개요

- 유저 비밀번호 변경 시, 현재 비밀번호가 필요하도록 수정

## ✅ 작업 내용

- Password 변경 로직 관련 Dto에 현재 비밀번호 속성 추가

## 🔨 변경 로직

- UserController 일부분 수정(chore)

## 🧨 관련 이슈

- #17  
