### PR TITLE
Feat : Upload Profile Photo

### DIFF
--- a/api_gate_way/src/config/database/prisma/schema.prisma
+++ b/api_gate_way/src/config/database/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   fetusNickname   String @default("아기")
   height          Int?
   weight          Int?
-  profilePhotoUrl String?
+  profilePhotoUrl String? @db.VarChar(521)
   createdAt       DateTime  @default(now())
   updatedAt       DateTime? @updatedAt
   deletedAt       DateTime?
@@ -31,7 +31,7 @@ model User {
 
 model ProfilePhoto {
   id Int @id @default(autoincrement())
-  url String @unique()
+  url String @db.VarChar(521) @unique()
   
   createdAt DateTime @default(now())
   updatedAt DateTime? @updatedAt
@@ -43,7 +43,7 @@ model ProfilePhoto {
 
 model PhotoAboutGeneration {
   id Int @id @default(autoincrement())
-  url String @unique()
+  url String @db.VarChar(521) @unique()
   
   createdAt DateTime @default(now())
   updatedAt DateTime? @updatedAt

--- a/api_gate_way/src/domain/photo/photo.controller.ts
+++ b/api_gate_way/src/domain/photo/photo.controller.ts
@@ -1,7 +1,38 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
 import { PhotoService } from './photo.service';
+import { TypedRoute } from '@nestia/core';
+import { JwtLocalGuard } from 'src/auth/guards/jwt-local.guard';
+import { UploadedFileMetadata } from '@nestjs/azure-storage';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ResponseForm,
+  responseForm,
+} from 'src/middlewares/interceptors/transform.interceptor';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+import { User } from 'src/middlewares/decorators/user.decorator';
+import { LocalToken } from 'src/dtos/auth/local-token.dto';
 
-@Controller('api/v1/photo')
+@Controller('/api/v1/photo')
 export class PhotoController {
   constructor(private readonly photoService: PhotoService) {}
+
+  @UseGuards(JwtLocalGuard)
+  @UseInterceptors(FileInterceptor('profile'))
+  @TypedRoute.Put('profile')
+  async uploadProfilePhoto(
+    @UploadedFile() profile: UploadedFileMetadata,
+    @User() user: LocalToken,
+  ): Promise<ResponseForm<UploadPhotoOutboundPortOutputDto>> {
+    const storageUrl = await this.photoService.uploadProfilePhoto(
+      profile,
+      user.id,
+    );
+
+    return responseForm(storageUrl);
+  }
 }

--- a/api_gate_way/src/domain/photo/photo.controller.ts
+++ b/api_gate_way/src/domain/photo/photo.controller.ts
@@ -16,11 +16,25 @@ import {
 import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
 import { User } from 'src/middlewares/decorators/user.decorator';
 import { LocalToken } from 'src/dtos/auth/local-token.dto';
+import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 
 @Controller('/api/v1/photo')
 export class PhotoController {
   constructor(private readonly photoService: PhotoService) {}
 
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
   @UseGuards(JwtLocalGuard)
   @UseInterceptors(FileInterceptor('profile'))
   @TypedRoute.Put('profile')

--- a/api_gate_way/src/domain/photo/photo.module.ts
+++ b/api_gate_way/src/domain/photo/photo.module.ts
@@ -6,6 +6,8 @@ import { PhotoRepository } from 'src/ports-adapters/photo/photo.repository';
 import { PHOTO_REPOSITORY_OUTBOUND_PORT } from 'src/ports-adapters/photo/photo.repository.outbound-port';
 import { AzureStorageModule } from '@nestjs/azure-storage';
 import { ConfigService } from '@nestjs/config';
+import { AZURE_STORAGE_OUTBOUND_PORT } from 'src/ports-adapters/azure/storage/azure.storage.outbound-port';
+import { AzureStorage } from 'src/ports-adapters/azure/storage/azure.storage';
 
 @Module({
   imports: [
@@ -26,6 +28,10 @@ import { ConfigService } from '@nestjs/config';
     {
       provide: PHOTO_REPOSITORY_OUTBOUND_PORT,
       useClass: PhotoRepository,
+    },
+    {
+      provide: AZURE_STORAGE_OUTBOUND_PORT,
+      useClass: AzureStorage,
     },
     PhotoService,
   ],

--- a/api_gate_way/src/domain/photo/photo.service.ts
+++ b/api_gate_way/src/domain/photo/photo.service.ts
@@ -1,4 +1,10 @@
+import { UploadedFileMetadata } from '@nestjs/azure-storage';
 import { Inject, Injectable } from '@nestjs/common';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+import {
+  AZURE_STORAGE_OUTBOUND_PORT,
+  AzureStorageOutboundPort,
+} from 'src/ports-adapters/azure/storage/azure.storage.outbound-port';
 import {
   PHOTO_REPOSITORY_OUTBOUND_PORT,
   PhotoRepositoryOutboundPort,
@@ -9,5 +15,30 @@ export class PhotoService {
   constructor(
     @Inject(PHOTO_REPOSITORY_OUTBOUND_PORT)
     private readonly photoRepository: PhotoRepositoryOutboundPort,
+
+    @Inject(AZURE_STORAGE_OUTBOUND_PORT)
+    private readonly azureStorage: AzureStorageOutboundPort,
   ) {}
+
+  async uploadProfilePhoto(
+    profile: UploadedFileMetadata,
+    userId: number,
+  ): Promise<UploadPhotoOutboundPortOutputDto> {
+    const { originalname, ...profileInfo } = profile;
+
+    const modifiedProfile = {
+      ...profileInfo,
+      originalname: `profile-${originalname}-${new Date().toISOString()}`,
+    };
+
+    const url = await this.azureStorage.uploadPhoto(modifiedProfile);
+
+    // 저장한 url을 DB 테이블에 저장
+    const storageUrl = await this.photoRepository.insertProfilePhotoUrl(
+      url.url,
+      userId,
+    );
+
+    return storageUrl;
+  }
 }

--- a/api_gate_way/src/dtos/photo/upload-profile-photo.dto.ts
+++ b/api_gate_way/src/dtos/photo/upload-profile-photo.dto.ts
@@ -1,0 +1,3 @@
+export type UploadPhotoOutboundPortOutputDto = {
+  url: string;
+};

--- a/api_gate_way/src/ports-adapters/azure/storage/azure.storage.outbound-port.ts
+++ b/api_gate_way/src/ports-adapters/azure/storage/azure.storage.outbound-port.ts
@@ -1,0 +1,11 @@
+import { UploadedFileMetadata } from '@nestjs/azure-storage';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+
+export const AZURE_STORAGE_OUTBOUND_PORT =
+  'AZURE_STORAGE_OUTBOUND_PORT' as const;
+
+export interface AzureStorageOutboundPort {
+  uploadPhoto(
+    modifiedProfile: UploadedFileMetadata,
+  ): Promise<UploadPhotoOutboundPortOutputDto>;
+}

--- a/api_gate_way/src/ports-adapters/azure/storage/azure.storage.ts
+++ b/api_gate_way/src/ports-adapters/azure/storage/azure.storage.ts
@@ -1,0 +1,27 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
+import { AzureStorageOutboundPort } from './azure.storage.outbound-port';
+import {
+  AzureStorageService,
+  UploadedFileMetadata,
+} from '@nestjs/azure-storage';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+
+@Injectable()
+export class AzureStorage implements AzureStorageOutboundPort {
+  constructor(private readonly azureStorage: AzureStorageService) {}
+  async uploadPhoto(
+    modifiedProfile: UploadedFileMetadata,
+  ): Promise<UploadPhotoOutboundPortOutputDto> {
+    const url = await this.azureStorage.upload(modifiedProfile);
+
+    if (!url) {
+      throw new ConflictException('이미지가 저장되지 않았습니다.');
+    }
+
+    return { url };
+  }
+}

--- a/api_gate_way/src/ports-adapters/photo/photo.repository.outbound-port.ts
+++ b/api_gate_way/src/ports-adapters/photo/photo.repository.outbound-port.ts
@@ -1,4 +1,11 @@
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+
 export const PHOTO_REPOSITORY_OUTBOUND_PORT =
   'PHOTO_REPOSITORY_OUTBOUND_PORT' as const;
 
-export interface PhotoRepositoryOutboundPort {}
+export interface PhotoRepositoryOutboundPort {
+  insertProfilePhotoUrl(
+    url: string,
+    userId: number,
+  ): Promise<UploadPhotoOutboundPortOutputDto>;
+}

--- a/api_gate_way/src/ports-adapters/photo/photo.repository.ts
+++ b/api_gate_way/src/ports-adapters/photo/photo.repository.ts
@@ -1,8 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { PhotoRepositoryOutboundPort } from './photo.repository.outbound-port';
 import { PrismaService } from 'src/config/database/prisma/prisma.service';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
 
 @Injectable()
 export class PhotoRepository implements PhotoRepositoryOutboundPort {
   constructor(private readonly prisma: PrismaService) {}
+  async insertProfilePhotoUrl(
+    url: string,
+    userId: number,
+  ): Promise<UploadPhotoOutboundPortOutputDto> {
+    const storageUrl = await this.prisma.profilePhoto.create({
+      data: { url, userId },
+      select: { url: true },
+    });
+
+    return storageUrl;
+  }
 }

--- a/api_gate_way/src/test/unit/mock/azure.storage.mock.ts
+++ b/api_gate_way/src/test/unit/mock/azure.storage.mock.ts
@@ -1,0 +1,24 @@
+import { UploadedFileMetadata } from '@nestjs/azure-storage';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+import { AzureStorageOutboundPort } from 'src/ports-adapters/azure/storage/azure.storage.outbound-port';
+import { MockParamTypeForTest } from 'src/utils/types/mock-param-type-for-test.type';
+
+type MockAzureStorageParamType = MockParamTypeForTest<MockAzureStorage>;
+
+export class MockAzureStorage implements AzureStorageOutboundPort {
+  private readonly result: MockAzureStorageParamType;
+
+  constructor(result: MockAzureStorageParamType) {
+    this.result = result;
+  }
+
+  async uploadPhoto(
+    modifiedProfile: UploadedFileMetadata,
+  ): Promise<UploadPhotoOutboundPortOutputDto> {
+    const res = this.result.uploadPhoto?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+    return res;
+  }
+}

--- a/api_gate_way/src/test/unit/mock/photo.repository.mock.ts
+++ b/api_gate_way/src/test/unit/mock/photo.repository.mock.ts
@@ -1,0 +1,24 @@
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+import { PhotoRepositoryOutboundPort } from 'src/ports-adapters/photo/photo.repository.outbound-port';
+import { MockParamTypeForTest } from 'src/utils/types/mock-param-type-for-test.type';
+
+type MockPhotoRepositoryParamType = MockParamTypeForTest<MockPhotoRepository>;
+
+export class MockPhotoRepository implements PhotoRepositoryOutboundPort {
+  private readonly result: MockPhotoRepositoryParamType;
+
+  constructor(result: MockPhotoRepositoryParamType) {
+    this.result = result;
+  }
+
+  async insertProfilePhotoUrl(
+    url: string,
+    userId: number,
+  ): Promise<UploadPhotoOutboundPortOutputDto> {
+    const res = this.result.insertProfilePhotoUrl?.pop();
+    if (res === undefined) {
+      throw new Error('undefined');
+    }
+    return res;
+  }
+}

--- a/api_gate_way/src/test/unit/photo.spec.ts
+++ b/api_gate_way/src/test/unit/photo.spec.ts
@@ -1,0 +1,42 @@
+import { PhotoService } from 'src/domain/photo/photo.service';
+import { LocalToken } from 'src/dtos/auth/local-token.dto';
+import typia from 'typia';
+import { MockPhotoRepository } from './mock/photo.repository.mock';
+import { MockAzureStorage } from './mock/azure.storage.mock';
+import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-photo.dto';
+import { PhotoController } from 'src/domain/photo/photo.controller';
+import { UploadedFileMetadata } from '@nestjs/azure-storage';
+
+describe('Photo Spec', () => {
+  let user: LocalToken;
+
+  beforeAll(async () => {
+    user = typia.random<LocalToken>();
+  });
+
+  describe('1. Upload Profile', () => {
+    it('1-1. Upload Profile Normally', async () => {
+      const url = typia.random<UploadPhotoOutboundPortOutputDto>();
+      const profile = typia.random<UploadedFileMetadata>();
+
+      const photoService = new PhotoService(
+        new MockPhotoRepository({
+          insertProfilePhotoUrl: [url],
+        }),
+        new MockAzureStorage({ uploadPhoto: [url] }),
+      );
+
+      const photoController = new PhotoController(photoService);
+
+      const res = await photoController.uploadProfilePhoto(
+        {
+          ...profile,
+          buffer: Buffer.alloc(1),
+        },
+        user,
+      );
+
+      expect(res.data).toStrictEqual(url);
+    });
+  });
+});


### PR DESCRIPTION
## 개요

- 사용자가 자신의 프로필 사진을 업로드 할 수 있다.

## ✅ 작업 내용

- insertProfilePhotoUrl in PhotoRepository
- uploadPhoto in AzureStorage
- uploadProfilePhoto in PhotoService
- uploadProfilePhoto in PhotoController
- Upload Profile test in PhotoSpec
- 이미지 처리를 위한 Swagger추가

## 🔨 변경 로직

- PhotoModule에 AzureStorage를 주입하기 위한 토큰 추가
- prisma.schema의 url관련 칼럼에 varchar(521) 설정

## 🧨 관련 이슈

- close #15 
