### PR TITLE
Fix : 회원가입 시, 비밀번호 확인 로직 추가

### DIFF
--- a/api_gate_way/src/dtos/user/create-user.dto.ts
+++ b/api_gate_way/src/dtos/user/create-user.dto.ts
@@ -1,10 +1,13 @@
 import { UserEntity } from 'src/config/database/models/user.entity';
 import { OmitProperties } from 'src/utils/types/omit.type';
 
-export type CreateUserDto = OmitProperties<
-  UserEntity,
-  'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
->;
+export interface CreateUserDto
+  extends OmitProperties<
+    UserEntity,
+    'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
+  > {
+  passwordConfirm: string;
+}
 
 export type CreateUserOutboundPortOutputDto = OmitProperties<
   UserEntity,

--- a/api_gate_way/src/ports-adapters/user/user.repository.ts
+++ b/api_gate_way/src/ports-adapters/user/user.repository.ts
@@ -28,7 +28,6 @@ import {
   UpdateUserPasswordOutboundPortOutputDtoForSelect,
   UpdateUserPhoneNumberOutboundPortOutputDto,
 } from 'src/dtos/user/update-user.dto';
-import { OmitProperties } from 'src/utils/types/omit.type';
 import {
   DeleteUserOutboundPortOutputDto,
   DeleteUserOutboundPortOutputDtoForSelect,
@@ -41,7 +40,11 @@ export class UserRepository implements UserRepositoryOutboundPort {
   async insertUser(
     userInfo: CreateUserDto,
   ): Promise<CreateUserOutboundPortOutputDto> {
-    const { password, ...data } = userInfo;
+    const { password, passwordConfirm, ...data } = userInfo;
+    if (password !== passwordConfirm) {
+      throw new BadRequestException('비밀번호와 비밀번호 확인이 다릅니다.');
+    }
+
     const hashedPassword = await bcrypt.hash(password, 10);
 
     const user = await this.prisma.user.create({

--- a/api_gate_way/src/test/unit/user.spec.ts
+++ b/api_gate_way/src/test/unit/user.spec.ts
@@ -42,7 +42,10 @@ describe('User Spec', () => {
 
       const userController = new UserController(userService);
 
-      const res = await userController.register(userInfo);
+      const res = await userController.register({
+        ...userInfo,
+        passwordConfirm: userInfo.password,
+      });
 
       expect(res.data).toStrictEqual(userInfo);
     });


### PR DESCRIPTION
## 개요

- 회원가입 시, 비밀번호 확인란을 통해 비밀번호를 알맞게 입력했는데 확인할 수 있다.

## ✅ 작업 내용

- 

## 🔨 변경 로직

- UserRepository에서 Password 확인 로직 추가
- Register User test에서 Password 확인 관련 로직 추가

## 🧨 관련 이슈

- close #38 
