### PR TITLE
Fix : upload user profile에 modifyFileName 함수 적용

### DIFF
--- a/api_gate_way/src/domain/photo/photo.service.ts
+++ b/api_gate_way/src/domain/photo/photo.service.ts
@@ -64,12 +64,7 @@ export class PhotoService {
     profile: UploadedFileMetadata,
     userId: number,
   ): Promise<UploadPhotoOutboundPortOutputDto> {
-    const { originalname, ...profileInfo } = profile;
-
-    const modifiedProfile = {
-      ...profileInfo,
-      originalname: `profile-${originalname}-${new Date().toISOString()}`,
-    };
+    const modifiedProfile = modifyFileName(profile, 'profile');
 
     const url = await this.azureStorage.uploadPhoto(modifiedProfile);
 

--- a/api_gate_way/src/test/unit/photo.spec.ts
+++ b/api_gate_way/src/test/unit/photo.spec.ts
@@ -33,6 +33,7 @@ describe('Photo Spec', () => {
       const res = await photoController.uploadProfilePhoto(
         {
           ...profile,
+          originalname: 'temp.png',
           buffer: Buffer.alloc(1),
         },
         user,


### PR DESCRIPTION
## 개요

- uploadProfilePhoto 함수에 modifyFileName 함수 적용

## ✅ 작업 내용

- apply modifyFileName at uploadProfilePhoto function in PhotoService

## 🔨 변경 로직

- PhotoSpec에 있는 관련 테스트 함수 변경

## 🧨 관련 이슈

- close #41 
