### PR TITLE
DOCS : 태아 사진 생성 컨트롤러에 이미지를 위한 스웨거 데코레이터 추가

### DIFF
--- a/api_gate_way/src/domain/photo/photo.controller.ts
+++ b/api_gate_way/src/domain/photo/photo.controller.ts
@@ -22,6 +22,19 @@ import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 export class PhotoController {
   constructor(private readonly photoService: PhotoService) {}
 
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
   @UseGuards(JwtLocalGuard)
   @UseInterceptors(FileInterceptor('fetus'))
   @TypedRoute.Post('fetus')


### PR DESCRIPTION


## 개요

- `/api-docs` 경로에서 createFetusPhoto 함수를 사용할 수 있다.

## ✅ 작업 내용

- add swagger decorator for image to createFetusPhoto in PhotoController


## 🔨 변경 로직

- 

## 🧨 관련 이슈

- close #43 
