### PR TITLE
Feat : Dockerfile Setting in API GATE WAY

### DIFF
--- a/api_gate_way/.dockerignore
+++ b/api_gate_way/.dockerignore
@@ -1,0 +1,45 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# .env
+.env*
+
+# swagger
+swagger.json
+
+# sdk
+packages
+src/api

--- a/api_gate_way/Dockerfile
+++ b/api_gate_way/Dockerfile
@@ -1,0 +1,32 @@
+#syntax=docker/dockerfile:1
+
+FROM node:16-alpine as builder
+
+WORKDIR /app
+
+COPY . .
+
+ENV NEST_PORT=3000
+
+RUN npm install --force && npm run build && npx nestia swagger
+
+
+FROM node:16-alpine as prod
+
+WORKDIR /app
+
+COPY ./package*.json ./
+
+COPY ./proto /app/proto
+
+COPY ./src/config/database/prisma /app/src/config/database/prisma
+
+COPY --from=builder /app/swagger.json ./
+
+COPY --from=builder /app/dist ./dist
+
+RUN npm install --force --omit=dev && npx prisma generate
+
+# env는 제외
+
+CMD ["npm", "run", "start:prod"]

--- a/api_gate_way/package.json
+++ b/api_gate_way/package.json
@@ -42,7 +42,8 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "swagger-ui-express": "^5.0.0",
-    "typia": "^4.1.8"
+    "typia": "^4.1.8",
+    "ts-patch": "^3.0.2"
   },
   "devDependencies": {
     "@nestia/e2e": "^0.3.6",
@@ -72,7 +73,6 @@
     "ts-jest": "28.0.8",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.9.1",
-    "ts-patch": "^3.0.2",
     "tsconfig-paths": "4.1.0",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
## 개요

- api_gate_way를 컨테이너로 띄울 수 있다.

## ✅ 작업 내용

- Dockerfile 작성
- `.dockerignore` 파일 작성

## 🔨 변경 로직

- ts-patch를 package.json의 dependecies로 이동

## 🧨 관련 이슈

- close #58 