### PR TITLE
Fix : URL에서 SAS 토큰 제거 및 유저 프로필 DB에 URL 추가 로직 작성

### DIFF
--- a/api_gate_way/nestia.config.ts
+++ b/api_gate_way/nestia.config.ts
@@ -11,6 +11,9 @@ export const config: INestiaConfig = {
     output: 'swagger.json',
     servers: [
       {
+        url: `http://localhost:80`,
+      },
+      {
         url: `http://localhost:${process.env.NEST_PORT}`,
         description: 'localhost',
       },

--- a/api_gate_way/src/domain/photo/photo.module.ts
+++ b/api_gate_way/src/domain/photo/photo.module.ts
@@ -10,6 +10,8 @@ import { AZURE_STORAGE_OUTBOUND_PORT } from 'src/ports-adapters/azure/storage/az
 import { AzureStorage } from 'src/ports-adapters/azure/storage/azure.storage';
 import { GENERATE_FETUS_GRPC_OUTBOUND_PORT } from 'src/ports-adapters/photo/generate-fetus/generate-fetus.grpc.outbound-port';
 import { GenerateFetusGRPC } from 'src/ports-adapters/photo/generate-fetus/generate-fetus.grpc';
+import { USER_REPOSITORY_OUTBOUND_PORT } from 'src/ports-adapters/user/user.repository.outbound-port';
+import { UserRepository } from 'src/ports-adapters/user/user.repository';
 
 @Module({
   imports: [
@@ -30,6 +32,10 @@ import { GenerateFetusGRPC } from 'src/ports-adapters/photo/generate-fetus/gener
     {
       provide: PHOTO_REPOSITORY_OUTBOUND_PORT,
       useClass: PhotoRepository,
+    },
+    {
+      provide: USER_REPOSITORY_OUTBOUND_PORT,
+      useClass: UserRepository,
     },
     {
       provide: AZURE_STORAGE_OUTBOUND_PORT,

--- a/api_gate_way/src/domain/photo/photo.service.ts
+++ b/api_gate_way/src/domain/photo/photo.service.ts
@@ -51,8 +51,6 @@ export class PhotoService {
         ext: modifiedFile.originalname.split('.').slice(-1).toString(),
       });
 
-    console.log(generatedFetusImageUrl);
-
     // 4. gRPC 서버에서 생후 사진 생성 후, Azure blob storage에 저장
 
     // 5. 그리고 gRPC서버에서는 생후 사진을 저장한 url을 nest.js서버로 전달

--- a/api_gate_way/src/domain/photo/photo.service.ts
+++ b/api_gate_way/src/domain/photo/photo.service.ts
@@ -13,6 +13,10 @@ import {
   PHOTO_REPOSITORY_OUTBOUND_PORT,
   PhotoRepositoryOutboundPort,
 } from 'src/ports-adapters/photo/photo.repository.outbound-port';
+import {
+  USER_REPOSITORY_OUTBOUND_PORT,
+  UserRepositoryOutboundPort,
+} from 'src/ports-adapters/user/user.repository.outbound-port';
 import { modifyFileName } from 'src/utils/functions/modify-file-name.function';
 
 @Injectable()
@@ -20,6 +24,9 @@ export class PhotoService {
   constructor(
     @Inject(PHOTO_REPOSITORY_OUTBOUND_PORT)
     private readonly photoRepository: PhotoRepositoryOutboundPort,
+
+    @Inject(USER_REPOSITORY_OUTBOUND_PORT)
+    private readonly userRepository: UserRepositoryOutboundPort,
 
     @Inject(AZURE_STORAGE_OUTBOUND_PORT)
     private readonly azureStorage: AzureStorageOutboundPort,
@@ -77,6 +84,11 @@ export class PhotoService {
       url.url,
       userId,
     );
+
+    // 저장한 url을 User의 profileUrl에 저장
+    const user = await this.userRepository.updateUserInfo(userId, {
+      profilePhotoUrl: storageUrl.url,
+    });
 
     return storageUrl;
   }

--- a/api_gate_way/src/ports-adapters/azure/storage/azure.storage.ts
+++ b/api_gate_way/src/ports-adapters/azure/storage/azure.storage.ts
@@ -12,11 +12,13 @@ export class AzureStorage implements AzureStorageOutboundPort {
   async uploadPhoto(
     modifiedProfile: UploadedFileMetadata,
   ): Promise<UploadPhotoOutboundPortOutputDto> {
-    const url = await this.azureStorage.upload(modifiedProfile);
+    const sasUrl = await this.azureStorage.upload(modifiedProfile);
 
-    if (!url) {
+    if (!sasUrl) {
       throw new ConflictException('이미지가 저장되지 않았습니다.');
     }
+
+    const url = sasUrl.split('?')[0];
 
     return { url };
   }

--- a/api_gate_way/src/test/unit/photo.spec.ts
+++ b/api_gate_way/src/test/unit/photo.spec.ts
@@ -7,6 +7,7 @@ import { UploadPhotoOutboundPortOutputDto } from 'src/dtos/photo/upload-profile-
 import { PhotoController } from 'src/domain/photo/photo.controller';
 import { UploadedFileMetadata } from '@nestjs/azure-storage';
 import { MockGenerateFetusGRPC } from './mock/generate-fetus.grpc.mock';
+import { MockUserRepository } from './mock/user.repository.mock';
 
 describe('Photo Spec', () => {
   let user: LocalToken;
@@ -24,6 +25,7 @@ describe('Photo Spec', () => {
         new MockPhotoRepository({
           insertProfilePhotoUrl: [url],
         }),
+        new MockUserRepository({}),
         new MockAzureStorage({ uploadPhoto: [url] }),
         new MockGenerateFetusGRPC({}),
       );
@@ -52,6 +54,7 @@ describe('Photo Spec', () => {
         new MockPhotoRepository({
           insertFetusPhotoUrl: [url, url],
         }),
+        new MockUserRepository({}),
         new MockAzureStorage({ uploadPhoto: [url] }),
         new MockGenerateFetusGRPC({
           generateFetusImage: [url],


### PR DESCRIPTION
## 개요

- DB에 저장되거나 사용자에게 제공되는 url에서 SAS token 제거
- User DB에 프로필 url 추가 로직 작성

## ✅ 작업 내용

- PhotoService에 UserRepository 주입
- AzureStorage의 uploadPhoto에 SAS token 제거 로직 추가
- PhotoService에 프로필 url 저장 로직 추가

## 🔨 변경 로직

- PhotoSpec에 MockUserRepository 주입

## 🧨 관련 이슈

- close #66 
